### PR TITLE
Replace the `>!` operator with the `>|` operator that is more compliant with the POSIX standard

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -22,7 +22,7 @@ function _current_epoch() {
 }
 
 function _update_zsh_custom_update() {
-  echo "LAST_EPOCH=$(_current_epoch)" >! "${ZSH_CACHE_DIR}/.zsh-custom-update"
+  echo "LAST_EPOCH=$(_current_epoch)" >| "${ZSH_CACHE_DIR}/.zsh-custom-update"
 }
 
 epoch_target=$UPDATE_ZSH_DAYS


### PR DESCRIPTION
Although the `>!` operator makes the code work, this implementation does not conform to the POSIX standard.

The POSIX compliant way to overwrite files without prompting is to use `>|` or `>>|` and this will work in any shell.

For information see [here](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07_02). 