### PR TITLE
Add quiet mode env var control

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/TamCore/autoupdate-oh-my-zsh-plugins $ZSH_CUSTOM/pl
 Add `autoupdate` to the `plugins=()` list in your `~/.zshrc` file and you're done.
 The updates will be executed automatically as soon as the oh-my-zsh updater is started.
 
-If you want to check for updates more often, you can adjust this line in the `~/.zshrc` file. 
+If you want to check for updates more often, you can adjust this line in the `~/.zshrc` file.
 Default command:
 ```shell
 # Uncomment the following line to change how often to auto-update (in days).
@@ -25,4 +25,13 @@ Changed command: (checks daily for updates)
 ```shell
 # Uncomment the following line to change how often to auto-update (in days).
 export UPDATE_ZSH_DAYS=1
+```
+
+### Quiet mode
+
+To turn off the "Upgrading custom plugins" message (for example, if you're using [Powerlevel10k's instant prompt](https://github.com/romkatv/powerlevel10k#instant-prompt)), add this to your `~/.zshrc` file:
+```shell
+# Uncomment the following line to change how often to auto-update (in days).
+# export UPDATE_ZSH_DAYS=13
+ZSH_CUSTOM_AUTOUPDATE_QUIET=true
 ```

--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -32,7 +32,9 @@ if [[ -z "$epoch_target" ]]; then
 fi
 
 function _upgrade_custom() {
-  printf "${BLUE}%s${NORMAL}\n" "Upgrading custom plugins"
+  if [[ -z "$ZSH_CUSTOM_AUTOUPDATE_QUIET" ]]; then
+    printf "${BLUE}%s${NORMAL}\n" "Upgrading custom plugins"
+  fi
 
   find "${ZSH_CUSTOM}" -type d -name .git | while read d
   do


### PR DESCRIPTION
Currently, every time the plugin runs `_upgrade_custom()`, it prints a little notice letting you know that custom plugins are being upgraded. This conflicts with the no user input/output approach of [Powerlevel10k's instant prompt](https://github.com/romkatv/powerlevel10k#instant-prompt).

I added an environment variable `ZSH_CUSTOM_AUTOUPDATE_QUIET` that can be set to silence the printing of `Upgrading custom plugins`. There are other ways this could be handled, so please let me know if you'd prefer another approach.

Of course, every time there are updates to be pulled, info will still be printed to `stdout`, which makes sense to me.

Thanks!