### PR TITLE
Upgrade at will

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ Changed command: (checks daily for updates)
 # Uncomment the following line to change how often to auto-update (in days).
 export UPDATE_ZSH_DAYS=1
 ```
+
+Another possibility is to use the provided upgrade function, which one may call
+at any time using `upgrade_oh_my_zsh_custom`. There shouldn't be any difference
+with the automatic operation. Also, a convenient alias that calls the OhMyZsh
+update function `upgrade_oh_my_zsh` and then `upgrade_oh_my_zsh_custom`, called
+`update_ohl_my_zsh`, is available as well.

--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -48,6 +48,9 @@ function upgrade_oh_my_zsh_custom() {
   done
 }
 
+alias upgrade_ohl_my_zsh='upgrade_oh_my_zsh && upgrade_oh_my_zsh_custom'
+
+
 if [ -f ~/.zsh-custom-update ]
 then
   mv ~/.zsh-custom-update "${ZSH_CACHE_DIR}/.zsh-custom-update"

--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -31,7 +31,7 @@ if [[ -z "$epoch_target" ]]; then
   epoch_target=13
 fi
 
-function _upgrade_custom() {
+function upgrade_oh_my_zsh_custom() {
   printf "${BLUE}%s${NORMAL}\n" "Upgrading custom plugins"
 
   find "${ZSH_CUSTOM}" -type d -name .git | while read d
@@ -67,13 +67,13 @@ then
   then
     if [ "$DISABLE_UPDATE_PROMPT" = "true" ]
     then
-      (_upgrade_custom)
+      (upgrade_oh_my_zsh_custom)
     else
       echo "[Oh My Zsh] Would you like to check for custom plugin updates? [Y/n]: \c"
       read line
       if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]
       then
-        (_upgrade_custom)
+        (upgrade_oh_my_zsh_custom)
       fi
     fi
     _update_zsh_custom_update
@@ -82,4 +82,4 @@ else
   _update_zsh_custom_update
 fi
 
-unset -f _update_zsh_custom_update _upgrade_custom _current_epoch
+unset -f _update_zsh_custom_update _current_epoch


### PR DESCRIPTION
Currently, the only way to run the upgrade of the custom themes and plugins is
to let time pass so the time check may be triggered by the UPDATE_ZSH_DAYS
configuration variable's delay. As it is in days only, one may run the upgrade
every day at most, which is sufficient really, but if an upgrade fails for whatever
reason, then it would convenient to do it again right after.

Therefore, two small modifications are proposed here:
 * Make the upgrade function public
 * Add an alias to upgrade everything at once

The first one is the most important one, while the second is proposed in order
to complete it further so it can be a bit more convenient. The names used may
be subject to discussion of course. Let me know your opinion.

I am not really able to test if it is 100% compatible with all types of configuration
neither if it is usable outside of a loaded OhMyZsh environment, but I don't
know if that is even possible. So could you guide me in this regard ?

Thanks in advance.