### PR TITLE
Tweak success and error messages

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -39,13 +39,14 @@ function upgrade_oh_my_zsh_custom() {
   find -L "${ZSH_CUSTOM}" -type d -name .git | while read d
   do
     p=$(dirname "$d")
+    pn=$(basename "$p")
     pushd -q "${p}"
 
     if git pull --rebase --stat origin master
     then
-      printf "${BLUE}%s${NORMAL}\n" "Hooray! $p has been updated and/or is at the current version."
+      printf "${BLUE}%s${NORMAL}\n" "Hooray! $pn has been updated and/or is at the current version."
     else
-      printf "${RED}%s${NORMAL}\n" "There was an error updating $p. Try again later?"
+      printf "${RED}%s${NORMAL}\n" "There was an error updating $pn. Try again later?"
     fi
     popd -q
   done

--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -40,13 +40,15 @@ function upgrade_oh_my_zsh_custom() {
   do
     p=$(dirname "$d")
     pn=$(basename "$p")
+    pt=$(dirname "$p")
+    pt=$(basename ${pt:0:((${#pt} - 1))})
     pushd -q "${p}"
 
     if git pull --rebase --stat origin master
     then
-      printf "${BLUE}%s${NORMAL}\n" "Hooray! $pn has been updated and/or is at the current version."
+      printf "${BLUE}%s${NORMAL}\n" "Hooray! the $pn $pt has been updated and/or is at the current version."
     else
-      printf "${RED}%s${NORMAL}\n" "There was an error updating $pn. Try again later?"
+      printf "${RED}%s${NORMAL}\n" "There was an error updating the $pn $pt. Try again later?"
     fi
     popd -q
   done


### PR DESCRIPTION
Hey again!

Usually, I'd say the full path to each plugin or theme is not really necessary in success or error messages, so I propose a couple of changes to shorten these:
 * Reduce plugin/theme path to base name only: `/home/<...>/.oh-my-zsh/custom/plugins/autoupdate` becomes just `autoupdate` in the messages.
 * Add type right after to compensate a bit: after `autoupdate` there is `plugin` added, but for `powerlevel10k` for example, there is `theme` instead. It is simply deduced from the parent directory.
 
Hope it's useful.
Cheers,
Paul.