### PR TITLE
Silence popd

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -47,7 +47,8 @@ function upgrade_oh_my_zsh_custom() {
     else
       printf "${RED}%s${NORMAL}\n" "There was an error updating $p. Try again later?"
     fi
-    popd -q
+
+    popd &>/dev/null
   done
 }
 


### PR DESCRIPTION
There seems to be a small issue: sometimes the directory stack is empty, so `popd` spits out something in the likes of: `upgrade_oh_my_zsh_custom:popd:16: directory stack empty`. I don't think this is a bug, so this PR suppresses these.

Cheers,
Paul.