### PR TITLE
Check current shell options instead file descriptor to detect interac…

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -5,7 +5,7 @@ if which tput >/dev/null 2>&1; then
   ncolors=$(tput colors)
 fi
 
-if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
+if [[ $- == *i* ]] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
   RED="$(tput setaf 1)"
   BLUE="$(tput setaf 4)"
   NORMAL="$(tput sgr0)"


### PR DESCRIPTION
…tive mode

According to [stackexchange](https://unix.stackexchange.com/a/26782) and [serverfault](https://serverfault.com/a/146747) thats the recommended way to check if the shell is running in interactive mode.

This fixes #20 (I had the same issue on my machine)
Before
![Bildschirmfoto 2022-02-10 um 20 17 24](https://user-images.githubusercontent.com/1990806/153481712-993b739d-865d-4563-9a2f-13057b7af34f.png)
After
![Bildschirmfoto 2022-02-10 um 20 18 14](https://user-images.githubusercontent.com/1990806/153481720-2c8c90d4-2038-4041-9247-f3c347291cd3.png)

