### PR TITLE
Rename: `upgrade_ohl_my_zsh` -> `upgrade_oh_my_zsh_all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Another possibility is to use the provided upgrade function, which one may call
 at any time using `upgrade_oh_my_zsh_custom`. There shouldn't be any difference
 with the automatic operation. Also, a convenient alias that calls the OhMyZsh
 update function `upgrade_oh_my_zsh` and then `upgrade_oh_my_zsh_custom`, called
-`upgrade_ohl_my_zsh`, is available as well.
+`upgrade_oh_my_zsh_all`, is available as well.
 
 ### Quiet mode
 

--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -55,7 +55,7 @@ function upgrade_oh_my_zsh_custom() {
   done
 }
 
-alias upgrade_ohl_my_zsh='omz update && upgrade_oh_my_zsh_custom'
+alias upgrade_oh_my_zsh_all='omz update && upgrade_oh_my_zsh_custom'
 
 
 if [ -f ~/.zsh-custom-update ]


### PR DESCRIPTION
Hi! This is just a request, but like this commenter https://github.com/TamCore/autoupdate-oh-my-zsh-plugins/pull/11#commitcomment-40476579, I found the name to be a little confusing. What do you think about renaming the alias to `upgrade_oh_my_zsh_all`?