### PR TITLE
Always run upgrade_oh_my_zsh_custom after omz update.

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -85,7 +85,7 @@ function upgrade_oh_my_zsh_custom() {
   set -m
 }
 
-alias upgrade_oh_my_zsh_all='omz update && upgrade_oh_my_zsh_custom'
+alias upgrade_oh_my_zsh_all='omz update; upgrade_oh_my_zsh_custom'
 
 
 if [ -f ~/.zsh-custom-update ]


### PR DESCRIPTION
Closes #33.

Under alias `upgrade_oh_my_zsh_all`, `upgrade_oh_my_zsh_custom` would not execute if the exit code of `omz update` is not 0.

This change to `upgrade_oh_my_zsh_all` will make `upgrade_oh_my_zsh_custom` always execute regardless of the output of `omz update`.