### PR TITLE
Prevent reloading of shell after omz update

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -87,7 +87,7 @@ function upgrade_oh_my_zsh_custom() {
   set -m
 }
 
-alias upgrade_oh_my_zsh_all='omz update; upgrade_oh_my_zsh_custom'
+alias upgrade_oh_my_zsh_all='omz update --unattended; upgrade_oh_my_zsh_custom'
 
 
 if [ -f ~/.zsh-custom-update ]


### PR DESCRIPTION
Fixes #33.

I was mistaken about the cause of `upgrade_oh_my_zsh_custom` not executing after `omz update`. See https://github.com/ohmyzsh/ohmyzsh/issues/12112

Adding `--unattended` would prevent reloading of shell after `omz update`, allowing `upgrade_oh_my_zsh_custom` to execute.