### PR TITLE
fix: replace deprecated `--unattended` flag.

### DIFF
--- a/autoupdate.plugin.zsh
+++ b/autoupdate.plugin.zsh
@@ -87,7 +87,7 @@ function upgrade_oh_my_zsh_custom() {
   set -m
 }
 
-alias upgrade_oh_my_zsh_all='omz update --unattended; upgrade_oh_my_zsh_custom'
+alias upgrade_oh_my_zsh_all='zsh "$ZSH/tools/upgrade.sh"; upgrade_oh_my_zsh_custom'
 
 
 if [ -f ~/.zsh-custom-update ]


### PR DESCRIPTION
## Changes

- Replace `omz update --unattended` with new equivalent `zsh "$ZSH/tools/upgrade.sh"`; the `--unattended` flag is no longer supported, use the `upgrade.sh` script instead. For more information see <https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#how-do-i-update-oh-my-zsh>